### PR TITLE
set default etherscan api_key to ''

### DIFF
--- a/cert_verifier/connectors.py
+++ b/cert_verifier/connectors.py
@@ -27,7 +27,7 @@ def createTransactionLookupConnector(chain=Chain.bitcoin_mainnet, options=None):
         if options and 'etherscan_api_token' in options:
             etherscan_api_token = options['etherscan_api_token']
         else:
-            etherscan_api_token = None
+            etherscan_api_token = ''
         return EtherscanConnector(chain, etherscan_api_token)
     return FallbackConnector(chain)
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -85,5 +85,9 @@ class TestVerify(unittest.TestCase):
         result = verifier.verify_certificate_file('data/2.0/eth_ropsten.json', options=options)
         self.assertEquals(StepStatus.passed.name, result[VERIFICATION_RESULT_INDEX]['status'])
 
+    def test_verify_cert_file_v2_eth_ropsten_no_api_token(self):
+        result = verifier.verify_certificate_file('data/2.0/eth_ropsten.json')
+        self.assertEquals(StepStatus.passed.name, result[VERIFICATION_RESULT_INDEX]['status'])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Set default etherscan api_key to '' instead of None. This can solve the following bug when trying to verify a Ethereum cert without specifying the options of API token.
```
$ python verifier.py ../tests/data/2.0/eth_ropsten.json 
../tests/data/2.0/eth_ropsten.json
Traceback (most recent call last):
  File "verifier.py", line 56, in <module>
    result = verify_certificate_file(cert_file)
  File "verifier.py", line 48, in verify_certificate_file
    result = verify_certificate(certificate_model, options)
  File "verifier.py", line 25, in verify_certificate
    connector = connectors.createTransactionLookupConnector(certificate_model.chain, options)
  File "/home/xieqihui/.virtualenvs/cert_verifier/lib/python3.5/site-packages/cert_verifier/connectors.py", line 31, in createTrans$
ctionLookupConnector
    return EtherscanConnector(chain, etherscan_api_token)
  File "/home/xieqihui/.virtualenvs/cert_verifier/lib/python3.5/site-packages/cert_verifier/connectors.py", line 199, in __init__
    self.url = url_prefix + '/api?module=proxy&action=eth_getTransactionByHash&apikey=' + api_key + '&txhash=%s'
TypeError: Can't convert 'NoneType' object to str implicitly
```
